### PR TITLE
Fixed the Microsoft Dependency Injection class name being wrong

### DIFF
--- a/src/AutoFactories.Microsoft.DependencyInjection/Views/Partials/FactoryConstructors.hbs
+++ b/src/AutoFactories.Microsoft.DependencyInjection/Views/Partials/FactoryConstructors.hbs
@@ -1,4 +1,4 @@
-﻿        public {{Type.Name}}Factory(global::System.IServiceProvider serviceProvider)
+﻿        public {{Type.Name}}(global::System.IServiceProvider serviceProvider)
         {
             __serviceProvider = serviceProvider;
         }


### PR DESCRIPTION
He would produce a compiler error saying 'Method must have return type' This was caused by `Factory` still being hard coded 