### PR TITLE
Fixed the issue where templates would not generate correctly

### DIFF
--- a/src/AutoFactories.Microsoft.DependencyInjection/AutoFactories.Microsoft.DependencyInjection.csproj
+++ b/src/AutoFactories.Microsoft.DependencyInjection/AutoFactories.Microsoft.DependencyInjection.csproj
@@ -10,8 +10,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Views\**\*.hbs" Pack="True" PackagePath="Views/" />
-    <None Include="$(MSBuildThisFileName).props" Pack="True" PackagePath="build" />
-    <None Include="$(MSBuildThisFileName).targets" Pack="True" PackagePath="build" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="6.0.2">

--- a/src/AutoFactories.Microsoft.DependencyInjection/AutoFactories.Microsoft.DependencyInjection.props
+++ b/src/AutoFactories.Microsoft.DependencyInjection/AutoFactories.Microsoft.DependencyInjection.props
@@ -1,5 +1,0 @@
-﻿<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
-  <ItemGroup>
-    <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\Views\**\*.hbs" Visible="false"/>
-  </ItemGroup>
-</Project>

--- a/src/AutoFactories.Microsoft.DependencyInjection/AutoFactories.Microsoft.DependencyInjection.targets
+++ b/src/AutoFactories.Microsoft.DependencyInjection/AutoFactories.Microsoft.DependencyInjection.targets
@@ -1,2 +1,0 @@
-﻿<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
-</Project>

--- a/src/AutoFactories.Ninject/AutoFactories.Ninject.csproj
+++ b/src/AutoFactories.Ninject/AutoFactories.Ninject.csproj
@@ -8,15 +8,4 @@
   <ItemGroup>
     <ProjectReference Include="..\AutoFactories\AutoFactories.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="Views\**\*.hbs" Pack="True" PackagePath="Views/" />
-    <None Include="$(MSBuildThisFileName).props" Pack="True" PackagePath="build" />
-    <None Include="$(MSBuildThisFileName).targets" Pack="True" PackagePath="build" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="6.0.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
 </Project>

--- a/src/AutoFactories.Ninject/AutoFactories.Ninject.props
+++ b/src/AutoFactories.Ninject/AutoFactories.Ninject.props
@@ -1,5 +1,0 @@
-﻿<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
-  <ItemGroup>
-    <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\Views\**\*.hbs" Visible="false"/>
-  </ItemGroup>
-</Project>

--- a/src/AutoFactories.Ninject/AutoFactories.Ninject.targets
+++ b/src/AutoFactories.Ninject/AutoFactories.Ninject.targets
@@ -1,2 +1,0 @@
-﻿<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
-</Project>

--- a/src/AutoFactories.nuget.props
+++ b/src/AutoFactories.nuget.props
@@ -1,0 +1,9 @@
+﻿<!-- == AutoFactories Nuget Properties ===
+  Contains common properties for packages once they are
+  published as NuGet packages.
+-->
+<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+  <ItemGroup>
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\Views\**\*.hbs"/>
+  </ItemGroup>
+</Project>

--- a/src/AutoFactories.nuget.targets
+++ b/src/AutoFactories.nuget.targets
@@ -1,0 +1,6 @@
+﻿<!-- == AutoFactories Nuget Targets ===
+  Contains common targets for packages once they are
+  published as NuGet packages.
+-->
+<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+</Project>

--- a/src/AutoFactories.sln
+++ b/src/AutoFactories.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFactories.Ninject", "Au
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{ADCCA55E-F297-4318-AB73-D23AE0F55937}"
 	ProjectSection(SolutionItems) = preProject
+		AutoFactories.nuget.props = AutoFactories.nuget.props
+		AutoFactories.nuget.targets = AutoFactories.nuget.targets
 		Directory.Build.props = Directory.Build.props
 		Nuget.props = Nuget.props
 	EndProjectSection

--- a/src/AutoFactories/AutoFactories.csproj
+++ b/src/AutoFactories/AutoFactories.csproj
@@ -2,16 +2,17 @@
 
   <PropertyGroup>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-    <None Include="Views\**\*.hbs" Pack="True" PackagePath="Views/" Visible="false" />
+    <Content Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="$(MSBuildThisFileName).props" Pack="True" PackagePath="build" />
     <None Include="$(MSBuildThisFileName).targets" Pack="True" PackagePath="build" />
-  
     <EmbeddedResource Include="Views\ClassAttribute.hbs" LogicalName="ClassAttribute.hbs" />
     <EmbeddedResource Include="Views\ParameterAttribute.hbs" LogicalName="ParameterAttribute.hbs" />
       <AdditionalFiles Include="Views\**\*.hbs" Exclude="@(EmbeddedResource)" />
+      <None Remove="AutoFactories.props" />
+      <None Remove="AutoFactories.targets" />
     <PackageReference Include="AutoInterface" />
     <PackageReference Include="Boxed.Mapping" Version="7.0.0" />
     <PackageReference Include="GitVersion.MsBuild" />

--- a/src/AutoFactories/AutoFactories.props
+++ b/src/AutoFactories/AutoFactories.props
@@ -1,5 +1,0 @@
-﻿<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
-  <ItemGroup>
-    <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\Views\**\*.hbs" Visible="false"/>
-  </ItemGroup>
-</Project>

--- a/src/AutoFactories/AutoFactories.targets
+++ b/src/AutoFactories/AutoFactories.targets
@@ -1,2 +1,0 @@
-﻿<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
-</Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,15 +1,25 @@
 <Project>
-    <PropertyGroup>
-      <Nullable>enable</Nullable>
-      <TargetFramework>netstandard2.0</TargetFramework>
-      <LangVersion>12</LangVersion>
-      <IncludeBuildOutput>false</IncludeBuildOutput>
-      <GitVersionTargetFramework>net8.0</GitVersionTargetFramework>
-    </PropertyGroup>
-    <ItemGroup>
-        <None Include="$(MSBuildThisFileDirectory)..\README.md" Pack="True" PackagePath="/" Visible="false" />
-        <None Include="$(MSBuildThisFileDirectory)..\LICENSE" Pack="True" PackagePath="/" Visible="false" />
-    </ItemGroup>
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>12</LangVersion>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <GitVersionTargetFramework>net8.0</GitVersionTargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- Auto Include Content -->
+    <None Include="$(MSBuildThisFileDirectory)..\README.md" Pack="True" PackagePath="/" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)..\LICENSE" Pack="True" PackagePath="/" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)AutoFactories.nuget.props" Pack="True" PackagePath="buildTransitive/$(MSBuildProjectName).props" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)AutoFactories.nuget.targets" Pack="True" PackagePath="buildTransitive/$(MSBuildProjectName).targets" Visible="false" />
+    <None Include="Views/**" Pack="True" PackagePath="Views"/>
+    
+    <!-- Shared References -->
+    <PackageReference Include="GitVersion.MsBuild" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
   <ImportGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
     <Import Project="Nuget.props"/>
   </ImportGroup>


### PR DESCRIPTION
The issue was resolved by switching the build scripts from `build` to `buildTransitive`. 

https://github.com/NuGet/Home/wiki/Allow-package--authors-to-define-build-assets-transitive-behavior