### PR TITLE
The generated factory interface has dynamic accessibility

### DIFF
--- a/src/AutoFactories.Tests/AccessModiferTests.cs
+++ b/src/AutoFactories.Tests/AccessModiferTests.cs
@@ -1,0 +1,29 @@
+﻿using Ninject.AutoFactories;
+using static Ninject.AutoFactories.AccessModifier;
+
+namespace AutoFactories.Tests
+{
+    public class AccessModiferTests
+    {
+
+        [Theory]
+        [MemberData(nameof(MostRestrictiveTestData))]
+        public void MostRestrictive(AccessModifier left, AccessModifier right, AccessModifier expected)
+        {
+            Assert.Equal(expected, AccessModifier.MostRestrictive(left, right));
+        }
+
+
+
+        public static TheoryData<AccessModifier, AccessModifier, AccessModifier> MostRestrictiveTestData()
+        {
+            return new TheoryData<AccessModifier, AccessModifier, AccessModifier>
+            {
+                { Public, Internal, Internal },
+                { Internal, Protected, Protected },
+                { Protected, ProtectedAndInternal, ProtectedAndInternal },
+                { ProtectedAndInternal, Private, Private }
+            };
+        }
+    }
+}

--- a/src/AutoFactories.Tests/CompileResult.cs
+++ b/src/AutoFactories.Tests/CompileResult.cs
@@ -1,0 +1,7 @@
+﻿using Microsoft.CodeAnalysis;
+using System.Collections.Immutable;
+
+namespace AutoFactories.Tests
+{
+    internal record CompileResult(SyntaxTree SyntaxTree, Compilation Compilation, SemanticModel SemanticModel, ImmutableArray<Diagnostic> Diagnostics);
+}

--- a/src/AutoFactories.Tests/SyntaxVisitorTests.cs
+++ b/src/AutoFactories.Tests/SyntaxVisitorTests.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.CodeAnalysis;
+using AutoFactories.Visitors;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using FluentAssertions;
+using Ninject.AutoFactories;
+
+namespace AutoFactories.Tests
+{
+    public class SyntaxVisitorTests
+    {
+
+        [Fact]
+        public void PublicClass_CreatesPublicFactory()
+            => Compose("""
+                public class MyClass
+                {
+
+                }
+                """,
+                CreatesPublicFactory);
+
+        [Fact]
+        public void InternalClass_CreatesInternalFactory()
+            => Compose("""
+                internal class MyClass
+                {}
+                """,
+                CreatesInternalFactory);
+
+        [Fact]
+        public void PublicClass_WithExposedPublicInterface_CreatesPublicFactory()
+            => Compose("""
+                using AutoFactories;
+
+                public interface IHuman {}
+                [AutoFactory(ExposeAs=typeof(IHuman))]
+                internal class Human : IHuman {}
+                """,
+                CreatesPublicFactory);
+
+
+        private void Compose(string source, params Action<ClassDeclarationVisitor>[] asserts)
+        {
+            UnitTestCompiler compiler = new UnitTestCompiler();
+            CompileResult result = compiler.Compile([source]);
+
+            Diagnostic[] errors = result.Diagnostics
+                .Where(d => d.Severity == DiagnosticSeverity.Error)
+                .ToArray();
+
+            if(errors.Length > 0)
+            {
+                Assert.Fail($"There were compiler errors\n - {string.Join("\n -", errors.Select(e => e.GetMessage()))}");
+            }
+
+            ClassDeclarationVisitor visitor = new ClassDeclarationVisitor(true, new Options(), result.SemanticModel);
+
+            visitor.VisitClassDeclaration(result.SyntaxTree
+                .GetRoot()
+                .ChildNodes()
+                .OfType<ClassDeclarationSyntax>()
+                .First());
+
+            foreach (Action<ClassDeclarationVisitor> assert in asserts)
+            {
+                assert(visitor);
+            }
+        }
+
+
+
+        private static Action<ClassDeclarationVisitor> CreatesPublicFactory => CreateFactoryThatIs(AccessModifier.Public);
+        private static Action<ClassDeclarationVisitor> CreatesInternalFactory => CreateFactoryThatIs(AccessModifier.Internal);
+
+        private static Action<ClassDeclarationVisitor> CreateFactoryThatIs(AccessModifier modifier)
+            => c => c.Accessibility.Should().Be(modifier);
+    }
+}

--- a/src/AutoFactories.Tests/UnitTestCompiler.cs
+++ b/src/AutoFactories.Tests/UnitTestCompiler.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis;
+using System.Reflection;
+using FluentAssertions;
+using System.Collections.Immutable;
+
+namespace AutoFactories.Tests
+{
+    internal class UnitTestCompiler
+    {
+        private ImmutableArray<MetadataReference> m_references;
+        private readonly CSharpCompilationOptions m_csharpCompileOptions;
+        private readonly AutoFactoriesGeneratorHoist m_generatorHost;
+
+        public UnitTestCompiler()
+        {
+            m_csharpCompileOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable);
+
+            AutoFactoriesGenerator generator = new AutoFactoriesGenerator();
+            generator.ExceptionHandler += OnGeneratorException;
+
+            m_generatorHost = new AutoFactoriesGeneratorHoist(generator);
+
+            m_references = AppDomain.CurrentDomain.GetAssemblies()
+                .Where(a => !string.IsNullOrWhiteSpace(a.Location))
+                .Where(a => !a.IsDynamic)
+                .Select<Assembly, MetadataReference>(a => MetadataReference.CreateFromFile(a.Location))
+                .ToImmutableArray();
+        }
+
+
+        public CompileResult Compile(string[] source, AdditionalText[]? additionalTexts = null)
+        {
+            additionalTexts ??= Array.Empty<AdditionalText>();
+
+            SyntaxTree[] syntaxTrees = source
+                .Select(s => CSharpSyntaxTree.ParseText(s))
+                .ToArray();
+
+            CSharpCompilation compilation = CSharpCompilation.Create("UnitTests", syntaxTrees, m_references, m_csharpCompileOptions);
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(m_generatorHost)
+                .AddAdditionalTexts(additionalTexts.ToImmutableArray())
+                .RunGeneratorsAndUpdateCompilation(compilation, out Compilation generatorCompilation, out ImmutableArray<Diagnostic> _);
+
+            SemanticModel semanticModel = generatorCompilation.GetSemanticModel(syntaxTrees[0]);
+            ImmutableArray<Diagnostic> diagnostics = generatorCompilation.GetDiagnostics();
+
+            return new CompileResult(syntaxTrees[0], generatorCompilation, semanticModel, diagnostics);
+        }
+
+
+        /// <summary>
+        /// Invoked when the generator throws an exception
+        /// </summary>
+        /// <param name="exception"></param>
+        private void OnGeneratorException(Exception exception)
+        {
+            Assert.Fail($"An unhandled exception was thrown while generating.\n{exception}");
+        }
+    }
+}

--- a/src/AutoFactories/AutoFactoriesAnalyzer.cs
+++ b/src/AutoFactories/AutoFactoriesAnalyzer.cs
@@ -44,13 +44,13 @@ namespace AutoFactories
             {
                 ClassDeclarationSyntax classDeclarationSyntax = (ClassDeclarationSyntax)context.Node;
                 Options options = new(context.Options.AnalyzerConfigOptionsProvider);
-                ClassDeclartionVisitor visitor = new(true, options, context.SemanticModel);
+                ClassDeclarationVisitor visitor = new(true, options, context.SemanticModel);
                 visitor.VisitClassDeclaration(classDeclarationSyntax);
                 Analyze(visitor, context);
             }, SyntaxKind.ClassDeclaration);
         }
 
-        private void Analyze(ClassDeclartionVisitor vistor, SyntaxNodeAnalysisContext context)
+        private void Analyze(ClassDeclarationVisitor vistor, SyntaxNodeAnalysisContext context)
         {
             foreach(Diagnostic diagnostic in vistor.GetDiagnostics())
             {

--- a/src/AutoFactories/AutoFactoriesGenerator.cs
+++ b/src/AutoFactories/AutoFactoriesGenerator.cs
@@ -40,7 +40,7 @@ namespace AutoFactories
 
         public override void OnInitialize(SgfInitializationContext context)
         {
-            IncrementalValueProvider<(ImmutableArray<AdditionalText> Left, (AnalyzerConfigOptionsProvider Left, ImmutableArray<ClassDeclartionVisitor?> Right) Right)> provider =
+            IncrementalValueProvider<(ImmutableArray<AdditionalText> Left, (AnalyzerConfigOptionsProvider Left, ImmutableArray<ClassDeclarationVisitor?> Right) Right)> provider =
                 context.AdditionalTextsProvider
                     .Where(IsHandlebarsText).Collect().Combine(
                         context.AnalyzerConfigOptionsProvider
@@ -122,7 +122,7 @@ namespace AutoFactories
             SgfSourceProductionContext context,
             ImmutableArray<ViewResourceText> templateTexts,
             AnalyzerConfigOptionsProvider configOptions,
-            ImmutableArray<ClassDeclartionVisitor> visitors)
+            ImmutableArray<ClassDeclarationVisitor> visitors)
         {
             Options options = new(configOptions);
             foreach (AdditionalText text in templateTexts)
@@ -134,7 +134,7 @@ namespace AutoFactories
                 .AddTemplateTexts(templateTexts)
                 .Build();
 
-            IEnumerable<ClassDeclartionVisitor> validVisitors = visitors
+            IEnumerable<ClassDeclarationVisitor> validVisitors = visitors
                 .Where(visitor => !visitor.GetDiagnostics().Any(v => v.Severity == DiagnosticSeverity.Error));
 
 
@@ -179,11 +179,11 @@ namespace AutoFactories
         /// <summary>
         /// Take in the nodes and transform them into vistiors which can be cached
         /// </summary>
-        private static ClassDeclartionVisitor? TransformNodes(GeneratorAttributeSyntaxContext context, CancellationToken token)
+        private static ClassDeclarationVisitor? TransformNodes(GeneratorAttributeSyntaxContext context, CancellationToken token)
         {
             ClassDeclarationSyntax classDeclarationSyntax = (ClassDeclarationSyntax)context.TargetNode;
 
-            ClassDeclartionVisitor visitor = new(false, s_options, context.SemanticModel);
+            ClassDeclarationVisitor visitor = new(false, s_options, context.SemanticModel);
 
             visitor.VisitClassDeclaration(classDeclarationSyntax);
 
@@ -191,7 +191,7 @@ namespace AutoFactories
         }
 
         /// <summary>
-        /// Filteres the source generator to only look at <see cref="ClassDeclarationSyntax"/> types
+        /// Filters the source generator to only look at <see cref="ClassDeclarationSyntax"/> types
         /// </summary>
         /// <param name="node">The node to check</param>
         /// <param name="token"><see cref="CancellationToken"/></param>

--- a/src/AutoFactories/Diagnostics/InconsistentFactoryAcessibility.cs
+++ b/src/AutoFactories/Diagnostics/InconsistentFactoryAcessibility.cs
@@ -15,7 +15,7 @@ namespace AutoFactories.Diagnostics
             Severity = DiagnosticSeverity.Error;
         }
 
-        public Diagnostic Build(ClassDeclartionVisitor visitor)
+        public Diagnostic Build(ClassDeclarationVisitor visitor)
             => Diagnostic.Create(Descriptor,
                 visitor.FactoryTypeLocation,
                 new object?[] { visitor.Type.QualifiedName, visitor.FactoryType.QualifiedName });

--- a/src/AutoFactories/Types/AccessModifier.cs
+++ b/src/AutoFactories/Types/AccessModifier.cs
@@ -1,27 +1,95 @@
 ﻿using Microsoft.CodeAnalysis;
-using Vogen;
+using System;
+using System.Collections.Generic;
 
 namespace Ninject.AutoFactories
 {
-    [Instance("Public", "public")]
-    [Instance("Internal", "internal")]
-    [Instance("Private", "private")]
-    [Instance("Protected", "protected")]
-    [Instance("ProtectedAndInternal", "protected internal")]
-    [ValueObject<string>(conversions: Conversions.None, toPrimitiveCasting: CastOperator.Implicit)]
-    public partial struct AccessModifier 
+    public readonly struct AccessModifier : IComparable<AccessModifier>, IEquatable<AccessModifier>
     {
+        public static readonly AccessModifier Public = new AccessModifier("public", 6);
+        public static readonly AccessModifier Internal = new AccessModifier("internal", 4);
+        public static readonly AccessModifier Protected = new AccessModifier("protected", 3);
+        public static readonly AccessModifier ProtectedAndInternal = new AccessModifier("protected internal", 2);
+        public static readonly AccessModifier Private = new AccessModifier("private", 1);
+
+        public readonly string Value;
+        public readonly int Order;
+
+
+        private AccessModifier(string value, int order)
+        {
+            Value = value;
+            Order = order;
+        }
+
+        public static AccessModifier MostRestrictive(params AccessModifier[] modifiers)
+        {
+            AccessModifier result = modifiers[0];
+            for(int i = 1; i < modifiers.Length; i++)
+            {
+                if (modifiers[i].CompareTo(result) > 0)
+                {
+                    result = modifiers[i];
+                }
+            }
+            return result;
+        }
+
         public static AccessModifier FromSymbol(ISymbol symbol)
         {
             switch (symbol.DeclaredAccessibility)
             {
                 default:
                 case Accessibility.Internal: return Internal;
-                case Accessibility.Public: return Public; 
+                case Accessibility.Public: return Public;
                 case Accessibility.Protected: return Protected;
                 case Accessibility.ProtectedAndInternal: return ProtectedAndInternal;
                 case Accessibility.Private: return Private;
             }
         }
+
+        public bool Equals(AccessModifier other, IEqualityComparer<AccessModifier> comparer)
+        {
+            return comparer.Equals(this, other);
+        }
+
+        public readonly bool Equals(string primitive)
+        {
+            return Value.Equals(primitive);
+        }
+
+        public readonly bool Equals(string primitive, StringComparer comparer)
+        {
+            return comparer.Equals(Value, primitive);
+        }
+
+
+        public bool Equals(AccessModifier other)
+            => other.Order == Order;
+
+        public readonly override bool Equals(object obj)
+            => obj is AccessModifier other && Equals(other);
+
+        public int CompareTo(AccessModifier other)
+            => other.Order.CompareTo(Order);
+
+        public override string ToString()
+            => Value;
+
+        public override int GetHashCode()
+        {
+            int hashCode = -1519344079;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Value);
+            hashCode = hashCode * -1521134295 + Order.GetHashCode();
+            return hashCode;
+        }
+
+
+        public static bool operator ==(AccessModifier left, AccessModifier right) => left.Equals(right);
+        public static bool operator !=(AccessModifier left, AccessModifier right) => !(left == right);
+        public static bool operator ==(AccessModifier left, string right) => Equals(left.Value, right);
+        public static bool operator !=(AccessModifier left, string right) => !Equals(left.Value, right);
+        public static bool operator ==(string left, AccessModifier right) => Equals(left, right.Value);
+        public static bool operator !=(string left, AccessModifier right) => !Equals(left, right.Value);
     }
 }

--- a/src/AutoFactories/Visitors/FactoryDeclartion.cs
+++ b/src/AutoFactories/Visitors/FactoryDeclartion.cs
@@ -13,11 +13,11 @@ namespace AutoFactories.Visitors
     {
         public MetadataTypeName Type { get; }
         public AccessModifier AccessModifier { get; }
-        public IReadOnlyList<ClassDeclartionVisitor> Classes { get; }
+        public IReadOnlyList<ClassDeclarationVisitor> Classes { get; }
         public IReadOnlyList<ParameterSyntaxVisitor> Parameters { get; }
 
 
-        private FactoryDeclartion(MetadataTypeName type, IEnumerable<ClassDeclartionVisitor> classes)
+        private FactoryDeclartion(MetadataTypeName type, IEnumerable<ClassDeclarationVisitor> classes)
         {
             Type = type;
             Classes = classes.ToList();
@@ -27,14 +27,20 @@ namespace AutoFactories.Visitors
                 .Where(p => p.HasMarkerAttribute)
                 .ToList();
 
+            AccessModifier = AccessModifier.MostRestrictive(
+                Classes
+                .Select(c => c.Accessibility)
+                .ToArray());
+
+
             AccessModifier = Classes.Any(c => c.AccessModifier != AccessModifier.Public)
                     ? AccessModifier.Internal
                     : AccessModifier.Public;
         }
 
-        public static IEnumerable<FactoryDeclartion> Create(IEnumerable<ClassDeclartionVisitor> classes)
+        public static IEnumerable<FactoryDeclartion> Create(IEnumerable<ClassDeclarationVisitor> classes)
         {
-            foreach (IGrouping<MetadataTypeName, ClassDeclartionVisitor> grouping in classes.GroupBy(v => v.FactoryType))
+            foreach (IGrouping<MetadataTypeName, ClassDeclarationVisitor> grouping in classes.GroupBy(v => v.FactoryType))
             {
                 yield return new FactoryDeclartion(grouping.Key, grouping);
             }

--- a/src/AutoFactories/Visitors/ParameterSyntaxVisitor.cs
+++ b/src/AutoFactories/Visitors/ParameterSyntaxVisitor.cs
@@ -2,6 +2,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Ninject.AutoFactories;
 
 namespace AutoFactories.Visitors
 {
@@ -14,6 +15,8 @@ namespace AutoFactories.Visitors
         public string? Name { get; private set; }
         public MetadataTypeName Type { get; private set; }
         public bool HasMarkerAttribute { get; private set; }
+
+        public AccessModifier Accessibility { get; private set; }
 
         public Location? AttributeLocation { get; private set; }
 
@@ -45,6 +48,7 @@ namespace AutoFactories.Visitors
             HasMarkerAttribute = markerAttribute is not null;
             AttributeLocation = markerAttribute?.GetLocation();
             Type = new MetadataTypeName(typeSymbol.ToDisplayString());
+            Accessibility = AccessModifier.FromSymbol(typeSymbol);
         }
 
         private AttributeSyntax? GetMarkerAttribute(ParameterSyntax node)


### PR DESCRIPTION
If the class is public it will be public. If the class is private but uses the `ExposeAs=typeof(PublicType)` it will be allowed to be public again.

```cs
[AutoFactory]
public class Human {}

// generates 
public HumanFactory {}
public interface IHumanFactory {}
```

Internal class 
```cs
[AutoFactory]
internal class Human {}

// generates 
internal HumanFactory {}
internal interface IHumanFactory {}
```

Where using the expose as 

```cs
[AutoFactory(ExposeAs=typeof(IHuman)]]
internal class Human : IHuman {}

public interface IHuman {}

// generates 
public HumanFactory {}
public interface IHumanFactory {}
```
