### PR TITLE
Fixed a compiler error when a method parameter was called `request`

### DIFF
--- a/src/AutoFactories.Ninject/Views/Partial/FactoryMethod.hbs
+++ b/src/AutoFactories.Ninject/Views/Partial/FactoryMethod.hbs
@@ -5,7 +5,6 @@
 {{/each}}
             };
 
-            global::Ninject.Activation.IRequest request = __resolutionRoot.CreateRequest(typeof({{Type.QualifiedName}}), null, __parameters, isOptional: false, isUnique: true);
-            global::System.Collections.Generic.IEnumerable<object>
-    results = __resolutionRoot.Resolve(request);
-    return System.Linq.Enumerable.Single(System.Linq.Enumerable.Cast<{{Type.QualifiedName}}>(results));
+            global::Ninject.Activation.IRequest __request = __resolutionRoot.CreateRequest(typeof({{Type.QualifiedName}}), null, __parameters, isOptional: false, isUnique: true);
+            global::System.Collections.Generic.IEnumerable<object> __results = __resolutionRoot.Resolve(__request);
+            return System.Linq.Enumerable.Single(System.Linq.Enumerable.Cast<{{Type.QualifiedName}}>(__results));

--- a/src/AutoFactories/AutoFactories.csproj
+++ b/src/AutoFactories/AutoFactories.csproj
@@ -47,6 +47,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Update="SourceGenerator.Foundations" Version="2.0.13" />
-    <PackageReference Update="Vogen" Version="5.0.6" />
+    <PackageReference Update="Vogen" Version="7.0.3" />
   </ItemGroup>
 </Project>

--- a/src/AutoFactories/ViewModels/ParameterViewModel.cs
+++ b/src/AutoFactories/ViewModels/ParameterViewModel.cs
@@ -51,7 +51,7 @@ namespace AutoFactories.Models
         public static ParameterViewModel Map(ParameterSyntaxVisitor visitor)
             => new ParameterViewModel()
             {
-                Name = visitor.Name!.ToCamelCase(),
+                Name = visitor.Name?.ToCamelCase(),
                 Type = visitor.Type,
                 IsRequired = !visitor.HasMarkerAttribute
             };


### PR DESCRIPTION
Given the the following code the source generator would fail due to the name `request` already being defined. 

```cs
public class Builder
{
   public Builder([FromFactory] Request request)
   {}
}
```