### PR TITLE
Added a misssing namespace that broke Microsoft DI

### DIFF
--- a/src/AutoFactories.Microsoft.DependencyInjection/Views/Static/AutoFactoryServiceCollectionExtensions.cs.hbs
+++ b/src/AutoFactories.Microsoft.DependencyInjection/Views/Static/AutoFactoryServiceCollectionExtensions.cs.hbs
@@ -1,4 +1,5 @@
 {{> DiagnosticSuppressions}}
+using Microsoft.Extensions.DependencyInjection;
 
 /// <summary>
 /// Provides functionality for automatically binding factory interfaces to their corresponding implementations.


### PR DESCRIPTION
The namespace was missing for the generated `AutoFactoryServiceCollectionExtensions` causing a compiler error 